### PR TITLE
Add rotated L-shaped layouts and improve OSD

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Run
 - o (in Control Mode): toggle OSD on/off (default off)
 - ? (in Control Mode): help overlay
 - f (in Control Mode): force pane surface rebuild (refresh from vterm screen)
-- Arrows (in Control Mode): resize column/row splits (layouts 2x1/1x2)
+- Arrows (in Control Mode): resize column/row splits (L-shaped layouts)
   - The focused pane is outlined with a cyan border while in Control Mode.
 - Outside Control Mode: all keys go to the focused pane; when focus is video, keys are forwarded to mpv (space/pause, n/p next/prev, arrows, ASCII)
   - Video focus key support: ASCII, Space/Enter/Tab, arrows, Home/End, PgUp/PgDn, Ins/Del, F1–F12, Esc, Backspace; plus fallbacks for space (pause), n/p (next/prev)
@@ -58,8 +58,8 @@ Run
 Layouts
 - Portrait (90/270):
   - stack: 3 rows in 1 column (Top=C, Middle=A, Bottom=B by default)
-  - 2x1: two columns in first row (C | A), second row single column (B)
-  - 1x2: one column in first row (C), second row two columns (A | B)
+  - 2over1: two columns in first row (C | A), second row single column (B)
+  - 1over2: one column in first row (C), second row two columns (A | B)
 - Landscape (0/180):
   - stack: 3 rows in 1 column
   - row: 1 row in 3 columns
@@ -111,7 +111,7 @@ Flags
 
 - --no-config: do not auto-load the default config
 - --smooth: balanced playback preset (display-resample, no interp, linear tscale, early-flush, no shader cache)
-- --layout stack|row|2x1|1x2: select tiling mode (applies in any rotation)
+- --layout stack|row|2x1|1x2|1over2|2over1: select tiling mode (applies in any rotation)
 
 Runtime focus and input
 - Focus targets: C=video, A=btop (by default), B=syslog (by default). Use Tab in Control Mode to select.
@@ -120,7 +120,7 @@ Runtime focus and input
 OSD
 - Default off for a clean display. Toggle in Control Mode with 'o' or show the help overlay with '?'.
 - Long OSD lines wrap automatically to the viewport width.
-- Status line shows the current layout (stack, row, 2x1, 1x2).
+- Status line shows the current layout (stack, row, 2x1, 1x2, 1over2, 2over1).
 
 Behavioral defaults
 - Single-video auto-loop: if only one file is given and no playlist, looping is enabled automatically.

--- a/src/osd.c
+++ b/src/osd.c
@@ -85,8 +85,20 @@ static void render_text_to_rgba(font_ctx *f, const char *text, unsigned char **o
             for (int xx=0; xx<(int)g->bitmap.width; xx++){
                 int px = gx + xx; if (px<0 || px>=*w) continue;
                 unsigned char a = g->bitmap.buffer[yy*g->bitmap.width + xx];
+                // outline pass: set surrounding pixels to black
+                for (int oy=-1; oy<=1; oy++){
+                    int py2 = py + oy; if (py2<0 || py2>=*h) continue;
+                    for (int ox=-1; ox<=1; ox++){
+                        if (ox==0 && oy==0) continue;
+                        int px2 = px + ox; if (px2<0 || px2>=*w) continue;
+                        unsigned char *dst = &buf[(size_t)(py2 * (*w) + px2) * 4];
+                        if (dst[3] < a) {
+                            dst[0] = 0; dst[1] = 0; dst[2] = 0; dst[3] = a;
+                        }
+                    }
+                }
+                // main glyph pixel (white)
                 unsigned char *dst = &buf[(size_t)(py * (*w) + px) * 4];
-                // white text with alpha
                 dst[0] = 255; dst[1] = 255; dst[2] = 255; dst[3] = a;
             }
         }


### PR DESCRIPTION
## Summary
- add 1over2 and 2over1 layout modes for rotated displays and update documentation
- show help overlay automatically in command mode and position control OSD to avoid overlap
- render OSD text with a black outline for better readability

## Testing
- `make` *(fails: Package libdrm was not found; Package 'gbm' ... not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b52055829083229c736e2738a47b97