### PR TITLE
Improve OSD visibility, add config save shortcut and runtime playlist FIFO

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Run
 - `./kms_mosaic --config /path/profile.conf`
 - `./kms_mosaic --save-config /path/profile.conf`
 - `./kms_mosaic --save-config-default`
+- `./kms_mosaic --playlist-fifo /tmp/playlist.fifo`
 
 -Controls
 - Ctrl+Q: quit compositor (always active)
@@ -49,6 +50,7 @@ Run
 - o (in Control Mode): toggle OSD on/off (default off)
 - ? (in Control Mode): help overlay
 - f (in Control Mode): force pane surface rebuild (refresh from vterm screen)
+- s (in Control Mode): save current configuration as default
 - Arrows (in Control Mode): resize column/row splits (L-shaped layouts)
   - The focused pane is outlined with a cyan border while in Control Mode.
 - Outside Control Mode: all keys go to the focused pane; when focus is video, keys are forwarded to mpv (space/pause, n/p next/prev, arrows, ASCII)
@@ -88,6 +90,7 @@ Flags
 - --video PATH: path to media file for the left pane. Optional.
 - --video-opt K=V: apply mpv option to the most recent --video (repeatable per item).
 - --playlist FILE: load an mpv playlist file (m3u, one path per line).
+- --playlist-fifo PATH: read newline-delimited video paths at runtime and append to the playlist.
 - --playlist-extended FILE: custom playlist with per-line options (each line: "path | key=val,key=val").
 - --no-video: disable the video region and use full width for the text panes.
 - --loop-file: loop the current file indefinitely.

--- a/src/osd.h
+++ b/src/osd.h
@@ -11,5 +11,6 @@ void osd_destroy(osd_ctx* o);
 void osd_set_text(osd_ctx* o, const char *text);
 
 // Draw at pixel position (x,y) in the logical render target of size (fb_w, fb_h)
-void osd_draw(osd_ctx* o, int x, int y, int fb_w, int fb_h);
+// `wrap_w` specifies the effective width for text wrapping after rotation
+void osd_draw(osd_ctx* o, int x, int y, int fb_w, int fb_h, int wrap_w);
 


### PR DESCRIPTION
## Summary
- ensure OSD and control mode overlays wrap within screen bounds based on rotation
- draw thicker text for OSD/help for better readability
- allow saving current layout via `s` in Control Mode
- support `--playlist-fifo` to append videos while running

## Testing
- `make` *(fails: Package libdrm was not found; Package 'gbm' not found; Package 'egl' not found; Package 'glesv2' not found; Package 'mpv' not found; Package 'vterm' not found; src/kms_mpv_compositor.c:26:10: fatal error: drm.h: No such file or directory)*
- `apt-get update` *(fails: repository InRelease not signed / 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b5cb9b72c48322ab782b4d32fd6529