### PR TITLE
Ensure OSD bounds and playlist FIFO looping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Semantic Versioning when version numbers are introduced.
 ### Added
 - Control Mode fullscreen toggle (`z`), with `n/p` navigation and `a` auto-rotate (interval via `--fs-cycle-sec`).
 
+### Changed
+- OSD, menu, and help text now render white on a black box and stay within screen bounds, including in portrait mode.
+- `--playlist-fifo` playlists automatically loop back to the first entry when the last video finishes.
+
 ## [0.2.1] - 2025-09-01
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Run
 - `./kms_mosaic --save-config-default`
 - `./kms_mosaic --playlist-fifo /tmp/playlist.fifo`
   - create fifo: `mkfifo /tmp/playlist.fifo` then `echo /path/video.mp4 > /tmp/playlist.fifo`
+  - playlist loops back to the first entry when the last video ends
 
 -Controls
 - Ctrl+Q: quit compositor (always active)
@@ -95,6 +96,7 @@ Flags
 - --video-opt K=V: apply mpv option to the most recent --video (repeatable per item).
 - --playlist FILE: load an mpv playlist file (m3u, one path per line).
 - --playlist-fifo PATH: watch a named pipe for newline-delimited video paths; use `mkfifo PATH` then write file paths to it to append.
+  Playlist automatically loops back to the first entry when reaching the end.
 - --roles XYZ: set initial slot order of panes (e.g., CAB); saved with `--save-config`.
 - --playlist-extended FILE: custom playlist with per-line options (each line: "path | key=val,key=val").
 - --no-video: disable the video region and use full width for the text panes.

--- a/src/kms_mpv_compositor.c
+++ b/src/kms_mpv_compositor.c
@@ -1472,6 +1472,8 @@ int main(int argc, char **argv) {
         }
     }
 
+    if (opt.playlist_fifo) opt.loop_playlist = true;
+
     if (opt.playlist_ext) parse_playlist_ext(&opt, opt.playlist_ext);
 
     // If exactly one video file is provided and no playlist,
@@ -2303,7 +2305,7 @@ int main(int argc, char **argv) {
             glBindFramebuffer(GL_FRAMEBUFFER, rt_fbo);
             gl_reset_state_2d();
             glViewport(0,0, logical_w, logical_h);
-            int wrap_w = (opt.rotation==ROT_90 || opt.rotation==ROT_270) ? logical_h : logical_w;
+            int wrap_w = logical_w;
             osd_draw(osd, 16, 16, logical_w, logical_h, wrap_w);
         }
         // Control-mode indicator OSD (always visible when active)
@@ -2314,7 +2316,7 @@ int main(int argc, char **argv) {
             gl_reset_state_2d();
             glViewport(0,0, logical_w, logical_h);
             int cm_y = display_help ? (logical_h - (opt.font_px?opt.font_px:20) - 16) : 48;
-            int wrap_w = (opt.rotation==ROT_90 || opt.rotation==ROT_270) ? logical_h : logical_w;
+            int wrap_w = logical_w;
             osd_draw(osdcm, 16, cm_y, logical_w, logical_h, wrap_w);
             // Highlight focused pane with a border
             int bx=0, by=0, bw=0, bh=0; int thickness = 4;

--- a/src/osd.c
+++ b/src/osd.c
@@ -152,6 +152,26 @@ void osd_draw(osd_ctx* o, int x, int y, int fb_w, int fb_h, int wrap_w){
     render_text_to_rgba(&o->font, wrapped, &rgba, &w, &h);
     free(wrapped);
     if(w<=0||h<=0){ free(rgba); return; }
+    // Clamp so text stays on screen
+    if (x + w > fb_w) x = fb_w - w;
+    if (y + h > fb_h) y = fb_h - h;
+    if (x < 0) x = 0;
+    if (y < 0) y = 0;
+    // Draw black background box with small margin
+    int margin = 8;
+    int bx = x - margin;
+    int by = y - margin;
+    int bw = w + margin*2;
+    int bh = h + margin*2;
+    if (bx < 0) bx = 0;
+    if (by < 0) by = 0;
+    if (bx + bw > fb_w) bx = fb_w - bw;
+    if (by + bh > fb_h) by = fb_h - bh;
+    glEnable(GL_SCISSOR_TEST);
+    glScissor(bx, fb_h - (by + bh), bw, bh);
+    glClearColor(0.f,0.f,0.f,1.f);
+    glClear(GL_COLOR_BUFFER_BIT);
+    glDisable(GL_SCISSOR_TEST);
     glBindTexture(GL_TEXTURE_2D, o->tex);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);


### PR DESCRIPTION
## Summary
- Keep OSD, menu and help text on screen with white text in a black box
- Wrap OSD width correctly in portrait orientation
- Automatically loop playlist when using `--playlist-fifo`

## Testing
- `make` *(fails: drm.h, vterm.h, EGL headers not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b5fc2dd10c8322b9b525631fd49fce