### PR TITLE
refactor: centralize font initialization

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ PKGS = libdrm gbm egl glesv2 mpv vterm freetype2 fontconfig
 PKG_CFLAGS := $(shell pkg-config --cflags $(PKGS))
 PKG_LIBS   := $(shell pkg-config --libs   $(PKGS))
 
-SRC = src/kms_mpv_compositor.c src/term_pane.c src/osd.c
+SRC = src/kms_mpv_compositor.c src/term_pane.c src/osd.c src/font_util.c
 BIN = kms_mosaic
 ALIAS = kms_mpv_compositor
 

--- a/src/font_util.c
+++ b/src/font_util.c
@@ -1,0 +1,43 @@
+#include "font_util.h"
+#include <fontconfig/fontconfig.h>
+#include <stdlib.h>
+#include <string.h>
+
+char *find_monospace_font(void) {
+    FcInit();
+    FcPattern *pat = FcNameParse((const FcChar8*)"monospace");
+    FcConfigSubstitute(NULL, pat, FcMatchPattern);
+    FcDefaultSubstitute(pat);
+    FcResult res;
+    FcPattern *match = FcFontMatch(NULL, pat, &res);
+    FcPatternDestroy(pat);
+    if (!match)
+        return NULL;
+    FcChar8 *file = NULL;
+    char *out = NULL;
+    if (FcPatternGetString(match, FC_FILE, 0, &file) == FcResultMatch)
+        out = strdup((const char*)file);
+    FcPatternDestroy(match);
+    return out;
+}
+
+int font_util_init(FT_Library *ftlib, FT_Face *face, int px_size) {
+    if (FT_Init_FreeType(ftlib))
+        return -1;
+    char *path = find_monospace_font();
+    if (!path)
+        return -1;
+    int err = FT_New_Face(*ftlib, path, 0, face);
+    free(path);
+    if (err)
+        return -1;
+    FT_Set_Pixel_Sizes(*face, 0, px_size);
+    return 0;
+}
+
+void font_util_destroy(FT_Library ftlib, FT_Face face) {
+    if (face)
+        FT_Done_Face(face);
+    if (ftlib)
+        FT_Done_FreeType(ftlib);
+}

--- a/src/font_util.h
+++ b/src/font_util.h
@@ -1,0 +1,7 @@
+#pragma once
+#include <ft2build.h>
+#include FT_FREETYPE_H
+
+char *find_monospace_font(void);
+int font_util_init(FT_Library *ftlib, FT_Face *face, int px_size);
+void font_util_destroy(FT_Library ftlib, FT_Face face);


### PR DESCRIPTION
## Summary
- extract common FreeType setup into new `font_util` module
- refactor `osd` and `term_pane` to use shared font utilities

## Testing
- `make` *(fails: Package 'libdrm', required by 'virtual:world', not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b788154dc483228448306807e8519e