### PR TITLE
Fix duplicate fullscreen state declarations

### DIFF
--- a/src/kms_mpv_compositor.c
+++ b/src/kms_mpv_compositor.c
@@ -1779,7 +1779,6 @@ int main(int argc, char **argv) {
     if (getenv("KMS_MPV_NO_OSD")) show_osd = false;
     bool show_help = false; // OSD help overlay
     bool ui_control = false; // when true, keystrokes control mosaic instead of panes
-    bool fullscreen = false; int fs_pane = 0; bool fs_cycle=false; double fs_next_switch=0.0;
 
     bool running = true;
     const char *direct_env_once = getenv("KMS_MPV_DIRECT");


### PR DESCRIPTION
## Summary
- Remove duplicate declarations for fullscreen state variables in `kms_mpv_compositor.c`

## Testing
- `make` *(fails: Package libdrm was not found in the pkg-config search path; compilation terminated)*

------
https://chatgpt.com/codex/tasks/task_e_68b7ad720e0483229442ac461bbf8d53