### PR TITLE
Expand t key swap to work with any pane

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Run
 - Ctrl+E: toggle Control Mode. While active, compositor consumes layout/role keys.
 - Tab (in Control Mode): cycle focus among C/A/B (video, pane A, pane B)
 - l / L (in Control Mode): cycle layouts forward/back
-- t (in Control Mode): swap terminal panes A and B
+- t (in Control Mode): swap focused pane with the next pane
 - r / R (in Control Mode): rotate roles among (C video, A, B) / reverse
 - o (in Control Mode): toggle OSD on/off (default off)
 - ? (in Control Mode): help overlay


### PR DESCRIPTION
## Summary
- Swap the focused pane with the next pane when pressing `t` in Control Mode
- Clarify documentation, help text, and OSD strings for the new swap behavior

## Testing
- `make` *(fails: Package libdrm was not found in the pkg-config search path)*

------
https://chatgpt.com/codex/tasks/task_e_68b7b4d958248322b9b17a55a8c727a1