### PR TITLE
Add n/p controls for fullscreen pane navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,11 @@ Semantic Versioning when version numbers are introduced.
 ### Fixed
 - `--roles` flag now correctly assigns panes based on slot order.
 
+## [0.3.4] - 2025-09-07
+
+### Added
+- Control Mode: `n` and `p` keys navigate to next/previous pane when fullscreen.
+
 ## [0.3.0] - 2025-09-01
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Run
 - ? (in Control Mode): help overlay
 - f (in Control Mode): force pane surface rebuild (refresh from vterm screen)
 - z (in Control Mode): fullscreen the focused pane
+- n / p (in Control Mode, fullscreen): next / previous fullscreen pane
 - c (in Control Mode): cycle fullscreen panes
 - Arrows (in Control Mode): resize column/row splits (split layouts)
   - The focused pane is outlined with a cyan border while in Control Mode.

--- a/src/kms_mpv_compositor.c
+++ b/src/kms_mpv_compositor.c
@@ -1859,7 +1859,7 @@ int main(int argc, char **argv) {
 
     // Set TTY to raw mode for key forwarding
     struct termios rawt; if (tcgetattr(0, &g_oldt)==0) { g_have_oldt = 1; rawt = g_oldt; cfmakeraw(&rawt); tcsetattr(0, TCSANOW, &rawt); atexit(restore_tty); }
-            fprintf(stderr, "Controls: Ctrl+E Control Mode; in Control Mode: Tab focus C/A/B, Arrows resize, l/L layouts, r/R rotate roles, t swap focus/next, z fullscreen, c cycle FS, o OSD, ? help; Ctrl+Q quit.\n");
+            fprintf(stderr, "Controls: Ctrl+E Control Mode; in Control Mode: Tab focus C/A/B, Arrows resize, l/L layouts, r/R rotate roles, t swap focus/next, z fullscreen, n/p next/prev FS, c cycle FS, o OSD, ? help; Ctrl+Q quit.\n");
     int focus = use_mpv ? 0 : 1; // 0=video, 1=top pane, 2=bottom pane
     bool show_osd = false; // default OSD off
     if (getenv("KMS_MPV_NO_OSD")) show_osd = false;
@@ -1937,6 +1937,8 @@ int main(int argc, char **argv) {
                     else if (buf[i]=='r') { int p0=perm[0],p1=perm[1],p2=perm[2]; perm[0]=p1; perm[1]=p2; perm[2]=p0; opt.roles_set=true; opt.roles[0]=perm[0]; opt.roles[1]=perm[1]; opt.roles[2]=perm[2]; consumed=true; }
                     else if (buf[i]=='R') { int p0=perm[0],p1=perm[1],p2=perm[2]; perm[0]=p2; perm[1]=p0; perm[2]=p1; opt.roles_set=true; opt.roles[0]=perm[0]; opt.roles[1]=perm[1]; opt.roles[2]=perm[2]; consumed=true; }
                     else if (buf[i]=='z') { fullscreen = !fullscreen; if (fullscreen){ fs_pane=focus; fs_cycle=false; } consumed=true; }
+                    else if (buf[i]=='n' && fullscreen) { fs_pane = (fs_pane+1)%3; focus = fs_pane; fs_cycle=false; consumed=true; }
+                    else if (buf[i]=='p' && fullscreen) { fs_pane = (fs_pane+2)%3; focus = fs_pane; fs_cycle=false; consumed=true; }
                     else if (buf[i]=='c') { fs_cycle = !fs_cycle; if (fs_cycle){ fullscreen=true; fs_pane=focus; fs_next_switch=0.0; } else { fullscreen=false; } consumed=true; }
                     else if (buf[i]=='f') { term_pane_force_rebuild(tp_a); term_pane_force_rebuild(tp_b); consumed=true; }
                     else if (buf[i]=='?') { show_help = !show_help; consumed=true; }
@@ -2339,6 +2341,8 @@ int main(int argc, char **argv) {
                     "  r/R: rotate roles C/A/B\n"
                     "  t: swap focused pane with next\n"
                     "  z: fullscreen focused pane\n"
+                    "  n: next fullscreen pane\n"
+                    "  p: previous fullscreen pane\n"
                     "  c: cycle fullscreen panes\n"
                     "  Arrows: resize splits (2x1/1x2/2over1/1over2)\n"
                     "  f: force pane rebuild\n"


### PR DESCRIPTION
## Summary
- allow `n` and `p` keys to switch between fullscreen panes in Control Mode
- update on-screen help, README, and changelog for the new shortcuts

## Testing
- `make` *(fails: Package 'libdrm', 'gbm', 'egl', 'glesv2', 'mpv', 'vterm' not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b7b8398d2483229f926c7aa97d7de4