### PR TITLE
Add overlay mode with alpha-blended panes

### DIFF
--- a/src/kms_mpv_compositor.c
+++ b/src/kms_mpv_compositor.c
@@ -114,6 +114,7 @@ typedef struct {
     bool list_connectors;
     bool no_video;
     bool no_panes;
+    bool overlay;
     bool gl_test;
     bool diag;
     bool loop_file;
@@ -1314,6 +1315,7 @@ static void save_config(const options_t *opt, const char *path){ FILE *f=fopen(p
     if (opt->fs_cycle_sec) fprintf(f, "--fs-cycle-sec %d\n", opt->fs_cycle_sec);
     if (opt->pane_a_cmd) fprintf(f, "--pane-a '%s'\n", opt->pane_a_cmd);
     if (opt->pane_b_cmd) fprintf(f, "--pane-b '%s'\n", opt->pane_b_cmd);
+    if (opt->overlay) fprintf(f, "--overlay\n");
     if (opt->no_video) fprintf(f, "--no-video\n");
     if (opt->loop_file) fprintf(f, "--loop-file\n");
     if (opt->loop_playlist) fprintf(f, "--loop-playlist\n");
@@ -1382,6 +1384,7 @@ int main(int argc, char **argv) {
         else if (!strcmp(argv[i], "--list-connectors")) opt.list_connectors = true;
         else if (!strcmp(argv[i], "--no-video")) opt.no_video = true;
         else if (!strcmp(argv[i], "--no-panes")) opt.no_panes = true;
+        else if (!strcmp(argv[i], "--overlay")) opt.overlay = true;
         else if (!strcmp(argv[i], "--diag")) opt.diag = true;
         else if (!strcmp(argv[i], "--gl-test")) opt.gl_test = true;
         else if (!strcmp(argv[i], "--no-config")) opt.no_config = true;
@@ -1462,6 +1465,7 @@ int main(int argc, char **argv) {
                 "  --pane-split PCT        Top row height percentage for split layouts (default 50).\n"
                 "  --pane-a \"CMD\"           Command for Pane A (default: btop).\n"
                 "  --pane-b \"CMD\"           Command for Pane B (default: tail -f /var/log/syslog).\n"
+                "  --overlay             Draw panes over video with transparency.\n"
                 "  --layout M              stack | row | 2x1 | 1x2 | 2over1 | 1over2\n"
                 "  --roles RRR            Slot roles order, e.g. CAB (default CAB).\n"
                 "  --fs-cycle-sec SEC     Fullscreen cycle interval for 'c' key.\n\n"
@@ -1768,7 +1772,23 @@ int main(int argc, char **argv) {
     bool fs_cycle = false;
     double fs_next_switch = 0.0;
 
-    {
+    if (opt.overlay) {
+        int split_pct = opt.pane_split_pct ? opt.pane_split_pct : 50; if (split_pct<10) split_pct=10; if (split_pct>90) split_pct=90;
+        int col_pct = opt.right_frac_pct ? opt.right_frac_pct : 33; if (col_pct<10) col_pct=10; if (col_pct>90) col_pct=90;
+        int overlay_w = screen_w * col_pct / 100;
+        int htop = screen_h * split_pct / 100; int hbot = screen_h - htop;
+        pane_layout s0 = (pane_layout){ .x=0, .y=0, .w=screen_w, .h=screen_h };
+        pane_layout s1 = (pane_layout){ .x=screen_w - overlay_w, .y=screen_h - htop, .w=overlay_w, .h=htop };
+        pane_layout s2 = (pane_layout){ .x=screen_w - overlay_w, .y=0, .w=overlay_w, .h=hbot };
+        pane_layout slots[3] = { s0, s1, s2 };
+        lay_video = slots[perm[0]];
+        lay_a     = slots[perm[1]];
+        lay_b     = slots[perm[2]];
+        if (fullscreen) {
+            pane_layout full = (pane_layout){ .x=0,.y=0,.w=screen_w,.h=screen_h };
+            if (fs_pane==0) lay_video = full; else if (fs_pane==1) lay_a=full; else lay_b=full;
+        }
+    } else {
         int mode = opt.layout_mode; // 0=stack3,1=row3,2=2x1,3=1x2,4=2over1,5=1over2
         int split_pct = opt.pane_split_pct ? opt.pane_split_pct : 50; if (split_pct<10) split_pct=10; if (split_pct>90) split_pct=90;
         int col_pct = opt.right_frac_pct ? (100 - opt.right_frac_pct) : 50; if (col_pct<20) col_pct=20; if (col_pct>80) col_pct=80;
@@ -1853,6 +1873,10 @@ int main(int argc, char **argv) {
         else {
             char *argv_b[] = { "tail", "-f", "/var/log/syslog", NULL };
             tp_b = term_pane_create(&lay_b, font_px_b, "tail", argv_b);
+        }
+        if (opt.overlay) {
+            term_pane_set_alpha(tp_a, 192);
+            term_pane_set_alpha(tp_b, 192);
         }
         last_font_px_a = font_px_a; last_font_px_b = font_px_b; prev_a = lay_a; prev_b = lay_b;
     }

--- a/src/term_pane.h
+++ b/src/term_pane.h
@@ -35,6 +35,7 @@ bool term_measure_cell(int font_px, int *cell_w, int *cell_h);
 
 // Change the font pixel size and reallocate buffers accordingly.
 void term_pane_set_font_px(term_pane *tp, int font_px);
+void term_pane_set_alpha(term_pane *tp, uint8_t alpha);
 
 // Reset the libvterm screen to force a redraw (hard=1 clears).
 void term_pane_reset_screen(term_pane *tp, int hard);


### PR DESCRIPTION
## Summary
- Allow terminal panes to render with configurable alpha for blending
- Add `--overlay` runtime option and layout to place panes on top of video
- Wire compositor to apply translucent panes when overlay mode is active

## Testing
- `make` *(fails: libdrm, gbm, egl, glesv2, mpv, vterm not found)*
- `./kms_mosiac --help` *(fails: libdrm.so.2 missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b7ba8d4f0883229af41aed27e06676