### PR TITLE
Fix overlay layout flag and loop playlist by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Layouts
 - Pane role assignment (C=video, A, B) is a permutation over the 3 slots and can be rotated/swapped at runtime via r/R/t.
 
 Overlay mode
-- `--overlay` renders the video full-screen and draws the two terminal panes on top.
+- `--overlay` (alias of `--layout overlay`) renders the video full-screen and draws the two terminal panes on top.
 - Split orientation follows `--rotate`: 0/180 degrees split the screen vertically, while 90/270 degrees split horizontally. `--pane-split` sets the percentage (default 50).
 - Panes use alpha blending so the video remains visible beneath them.
 
@@ -112,7 +112,7 @@ Flags
 - --no-video: disable the video region and use full width for the text panes.
 - --loop-file: loop the current file indefinitely.
 - --loop: shorthand for --loop-file (infinite). Note: if you provide exactly one video and no playlist, looping is assumed by default.
-- --loop-playlist: loop the playlist indefinitely.
+- --loop-playlist: loop the playlist indefinitely (default when a playlist is provided).
 - --shuffle: randomize playlist order (alias: --randomize).
 - --mpv-opt K=V: set global mpv option (repeatable), e.g., --mpv-opt keepaspect=yes.
 - --mpv-out FILE: write mpv logs/events to FILE or FIFO.

--- a/src/kms_mpv_compositor.c
+++ b/src/kms_mpv_compositor.c
@@ -1531,6 +1531,14 @@ int main(int argc, char **argv) {
 
     if (opt.playlist_ext) parse_playlist_ext(&opt, opt.playlist_ext);
 
+    // Legacy --overlay flag should behave like --layout overlay
+    if (opt.overlay)
+        opt.layout_mode = 6;
+
+    // Auto-enable playlist looping to avoid exiting after the last entry
+    if (!opt.loop_playlist && (opt.playlist_path || opt.playlist_ext || opt.playlist_fifo))
+        opt.loop_playlist = true;
+
     // If exactly one video file is provided and no playlist,
     // assume --loop should be enabled unless user already set a loop.
     if (!opt.playlist_path && !opt.playlist_ext && !opt.playlist_fifo) {


### PR DESCRIPTION
## Summary
- make `--overlay` behave like `--layout overlay` so panes blend over the full-screen video
- automatically loop playlists to prevent crashes when reaching the end

## Testing
- `make` *(fails: Package libdrm was not found in the pkg-config search path, ...)*

------
https://chatgpt.com/codex/tasks/task_e_68b86347c9ac8322a3baae64011a258d