### PR TITLE
Display layout and help only in Control Mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Run
 - t (in Control Mode): swap focused pane with the next pane
 - r / R (in Control Mode): rotate roles among (C video, A, B) / reverse
 - o (in Control Mode): toggle OSD on/off (default off)
-- ? (in Control Mode): help overlay
+- Help text is shown automatically while in Control Mode
 - f (in Control Mode): force pane surface rebuild (refresh from vterm screen)
 - z (in Control Mode): fullscreen the focused pane
 - n / p (in Control Mode, fullscreen): next / previous fullscreen pane
@@ -136,9 +136,9 @@ Runtime focus and input
 - Outside Control Mode, keypresses go to the focused target. This keeps underlying programs (btop, shell, mpv) fully interactive.
 
 OSD
-- Default off for a clean display. Toggle in Control Mode with 'o' or show the help overlay with '?'.
+- Default off for a clean display. Toggle in Control Mode with 'o'.
 - Long OSD lines wrap automatically to the viewport width.
-- Status line shows the current layout (stack, row, 2x1, 1x2, 2over1, 1over2, overlay).
+- The current layout is shown in Control Mode, not in the OSD.
 
 Behavioral defaults
 - Single-video auto-loop: if only one file is given and no playlist, looping is enabled automatically.


### PR DESCRIPTION
## Summary
- Remove layout indicator from playback OSD and show it within Control Mode overlay
- Always display control help when Control Mode is active; '?' hotkey removed
- Document automatic help display and update OSD description

## Testing
- `make` *(fails: Package 'libdrm', required by 'virtual:world', not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b86b42b2888322a4c9960c8f21b0b1