### PR TITLE
Preserve overlay roles and add config save hotkey

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Run
 - o (in Control Mode): toggle OSD on/off (default off)
 - Help text is shown automatically while in Control Mode
 - f (in Control Mode): force pane surface rebuild (refresh from vterm screen)
+- s (in Control Mode): save current configuration to the default path
 - z (in Control Mode): fullscreen the focused pane
 - n / p (in Control Mode, fullscreen): next / previous fullscreen pane
 - c (in Control Mode): cycle fullscreen panes

--- a/src/kms_mpv_compositor.c
+++ b/src/kms_mpv_compositor.c
@@ -1766,8 +1766,20 @@ int main(int argc, char **argv) {
     static int last_perm[3] = {0,1,2};
     static bool overlay_swap = false; // track A/B order in overlay layout
     static bool last_overlay_swap = false;
-    if (opt.roles_set) { perm[0]=opt.roles[0]; perm[1]=opt.roles[1]; perm[2]=opt.roles[2]; }
-    if (opt.layout_mode == 6) { perm[0]=0; perm[1]=1; perm[2]=2; overlay_swap=false; last_overlay_swap=false; }
+    if (opt.roles_set) {
+        perm[0] = opt.roles[0];
+        perm[1] = opt.roles[1];
+        perm[2] = opt.roles[2];
+        if (opt.layout_mode == 6) {
+            overlay_swap = (opt.roles[1] == 2 && opt.roles[2] == 1);
+            opt.roles[0] = 0;
+        }
+    }
+    if (opt.layout_mode == 6) {
+        perm[0] = 0;
+        if (!opt.roles_set) { perm[1] = 1; perm[2] = 2; overlay_swap = false; }
+        last_overlay_swap = overlay_swap;
+    }
     static int last_font_px_a=-1, last_font_px_b=-1;
     static pane_layout prev_a={0}, prev_b={0};
     static int last_layout_mode=-1;
@@ -1959,7 +1971,13 @@ int main(int argc, char **argv) {
                     else if (buf[i]=='L') { opt.layout_mode = (opt.layout_mode+6)%7; consumed=true; }
                     else if (buf[i]=='t') {
                         if (opt.layout_mode == 6) {
-                            if (focus == 1 || focus == 2) overlay_swap = !overlay_swap;
+                            if (focus == 1 || focus == 2) {
+                                overlay_swap = !overlay_swap;
+                                opt.roles_set = true;
+                                opt.roles[0] = 0;
+                                opt.roles[1] = overlay_swap ? 2 : 1;
+                                opt.roles[2] = overlay_swap ? 1 : 2;
+                            }
                         } else {
                             int next = use_mpv ? (focus + 1) % 3 : (focus == 1 ? 2 : 1);
                             int tmp = perm[focus];
@@ -1979,6 +1997,7 @@ int main(int argc, char **argv) {
                     else if (buf[i]=='p' && fullscreen) { fs_pane = (fs_pane+2)%3; focus = fs_pane; fs_cycle=false; consumed=true; }
                     else if (buf[i]=='c') { fs_cycle = !fs_cycle; if (fs_cycle){ fullscreen=true; fs_pane=focus; fs_next_switch=0.0; } else { fullscreen=false; } consumed=true; }
                     else if (buf[i]=='f') { term_pane_force_rebuild(tp_a); term_pane_force_rebuild(tp_b); consumed=true; }
+                    else if (buf[i]=='s') { const char *p = default_config_path(); save_config(&opt, p); fprintf(stderr, "Saved config to %s\n", p); consumed=true; }
                 }
                 // While in UI control mode, handle arrow keys for resizing splits
                 if (ui_control) {
@@ -2136,7 +2155,17 @@ int main(int argc, char **argv) {
         {
             if (opt.layout_mode == 6) {
                 perm[0] = 0;
-                if (last_layout_mode != 6) { perm[1] = 1; perm[2] = 2; overlay_swap = false; last_overlay_swap = false; }
+                if (last_layout_mode != 6) {
+                    if (opt.roles_set) {
+                        perm[1] = opt.roles[1];
+                        perm[2] = opt.roles[2];
+                        overlay_swap = (opt.roles[1] == 2 && opt.roles[2] == 1);
+                        opt.roles[0] = 0;
+                    } else {
+                        perm[1] = 1; perm[2] = 2; overlay_swap = false;
+                    }
+                    last_overlay_swap = overlay_swap;
+                }
             }
             int layout_changed = 0;
             if (last_layout_mode != opt.layout_mode) { layout_changed = 1; last_layout_mode = opt.layout_mode; }


### PR DESCRIPTION
## Summary
- Keep overlay pane swap state and roles when saving config
- Initialize overlay layout from stored roles, preserving swap order
- Update config roles when toggling panes in overlay mode
- Add `s` hotkey in Control Mode to write configuration to default path

## Testing
- `make` *(fails: Package libdrm was not found; fatal error: drm.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b87dc0d46c8322ad9d2040f8cfe24e