### PR TITLE
Restore panscan hotkey

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Run
 -Controls
 - Ctrl+Q: quit compositor (always active)
 - Ctrl+E: toggle Control Mode. While active, compositor consumes layout/role keys.
-- Ctrl+P (video focus): toggle mpv panscan on/off.
+- Ctrl+P: toggle mpv panscan on/off.
 - Tab (in Control Mode): cycle focus among C/A/B (video, pane A, pane B)
 - l / L (in Control Mode): cycle layouts forward/back
 - t (in Control Mode): swap focused pane with the next pane
@@ -58,7 +58,6 @@ Run
 - Arrows (in Control Mode): resize column/row splits (split layouts)
   - The focused pane is outlined with a cyan border while in Control Mode.
 - Outside Control Mode: all keys go to the focused pane; when focus is video, keys are forwarded to mpv (space/pause, n/p next/prev, arrows, ASCII)
-  - Ctrl+P toggles mpv panscan without forwarding the key.
   - Video focus key support: ASCII, Space/Enter/Tab, arrows, Home/End, PgUp/PgDn, Ins/Del, F1–F12, Esc, Backspace; plus fallbacks for space (pause), n/p (next/prev)
 
 

--- a/src/kms_mosaic.c
+++ b/src/kms_mosaic.c
@@ -1512,9 +1512,8 @@ int main(int argc, char **argv) {
                 "  c             Cycle fullscreen panes.\n"
                 "  o             Toggle OSD visibility.\n"
                 "  (Help shown automatically in Control Mode)\n"
-                "  Ctrl+Q        Quit (only active in Control Mode).\n\n",
-                "  Ctrl+Q        Quit (only active in Control Mode).\n"
-                "Outside Control Mode (video focus):\n"
+                "  Ctrl+Q        Quit (only active in Control Mode).\n\n"
+                "Always:\n"
                 "  Ctrl+P        Toggle mpv panscan.\n\n",
                 exe);
             return 0;
@@ -1906,7 +1905,7 @@ int main(int argc, char **argv) {
 
     // Set TTY to raw mode for key forwarding
     struct termios rawt; if (tcgetattr(0, &g_oldt)==0) { g_have_oldt = 1; rawt = g_oldt; cfmakeraw(&rawt); tcsetattr(0, TCSANOW, &rawt); atexit(restore_tty); }
-            fprintf(stderr, "Controls: Ctrl+E Control Mode; in Control Mode: Tab focus C/A/B, Arrows resize, l/L layouts, r/R rotate roles, t swap focus/next, z fullscreen, n/p next/prev FS, c cycle FS, o OSD; Ctrl+Q quit.\n");
+    fprintf(stderr, "Controls: Ctrl+E Control Mode; in Control Mode: Tab focus C/A/B, Arrows resize, l/L layouts, r/R rotate roles, t swap focus/next, z fullscreen, n/p next/prev FS, c cycle FS, o OSD; Ctrl+P panscan; Ctrl+Q quit.\n");
     int focus = use_mpv ? 0 : 1; // 0=video, 1=top pane, 2=bottom pane
     bool show_osd = false; // default OSD off
     if (getenv("KMS_MPV_NO_OSD")) show_osd = false;
@@ -2035,8 +2034,8 @@ int main(int argc, char **argv) {
                 }
                 // OSD toggle only in UI control mode
                 if (ui_control) { for (ssize_t i=0;i<n;i++) if (buf[i]=='o') { show_osd = !show_osd; consumed=true; } }
-                // Ctrl+P: toggle mpv panscan when video is focused
-                if (!ui_control && focus==0 && use_mpv) {
+                // Ctrl+P: toggle mpv panscan
+                if (use_mpv) {
                     for (ssize_t i=0; i<n; i++) {
                         unsigned char ch = (unsigned char)buf[i];
                         if (ch == 0x10) { // Ctrl+P


### PR DESCRIPTION
## Summary
- allow Ctrl+P to toggle mpv panscan at any time
- document panscan hotkey in help text and README

## Testing
- `make` *(fails: drm.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b8b5f40588832297faea6ac8eca8bb