### PR TITLE
Fix overlay pane redraw and panscan toggle

### DIFF
--- a/src/kms_mosaic.c
+++ b/src/kms_mosaic.c
@@ -2042,7 +2042,9 @@ int main(int argc, char **argv) {
                             double cur = 0.0;
                             if (mpv_get_property(m.mpv, "panscan", MPV_FORMAT_DOUBLE, &cur) >= 0) {
                                 double target = cur > 0.0 ? 0.0 : (opt.panscan ? atof(opt.panscan) : 1.0);
-                                mpv_set_property(m.mpv, "panscan", MPV_FORMAT_DOUBLE, &target);
+                                char cmd[64];
+                                snprintf(cmd, sizeof(cmd), "set panscan %f", target);
+                                mpv_command_string(m.mpv, cmd);
                             }
                             consumed = true;
                             break;

--- a/src/term_pane.c
+++ b/src/term_pane.c
@@ -652,6 +652,11 @@ void term_pane_resize(term_pane *tp, const pane_layout *layout) {
     free(old.pixels);
     free(tp->row_hash);
     tp->row_hash = calloc((size_t)tp->layout.rows, sizeof(uint32_t));
+    /* The newly allocated surface may contain uninitialized areas when the
+     * pane grows. Re-render the current vterm screen so the texture is fully
+     * populated rather than showing transparent regions until the application
+     * outputs more text. */
+    rebuild_surface(tp);
 }
 
 static void update_changed_rows(term_pane *tp) {
@@ -865,6 +870,10 @@ void term_pane_set_font_px(term_pane *tp, int font_px) {
     free(old.pixels);
     free(tp->row_hash);
     tp->row_hash = calloc((size_t)rows, sizeof(uint32_t));
+    /* After changing font metrics, the pane surface is reallocated.  Ensure
+     * it reflects the current screen contents so the background is fully
+     * drawn with the new dimensions. */
+    rebuild_surface(tp);
 }
 
 void term_pane_set_alpha(term_pane *tp, uint8_t alpha) {


### PR DESCRIPTION
## Summary
- Rebuild terminal pane surfaces when resized or when font size changes to prevent transparent areas in overlay layouts
- Toggle mpv panscan via command string for both hotkey and flag support

## Testing
- `make` *(fails: Package 'libdrm' not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b8c36fa4cc8322b8b2c4b4273da874