### PR TITLE
Fix syslog fallback and panscan toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,8 @@ Flags
 - --video-frac PCT: percent of screen width for the video region (overrides --right-frac).
 - --pane-split PCT: percent of right column height for top pane (10..90, default 50).
 - --pane-a "CMD": shell command for top-right pane (default: btop).
-- --pane-b "CMD": shell command for bottom-right pane (default: tail -f /var/log/syslog).
+- --pane-b "CMD": shell command for bottom-right pane (default: tail -f /var/log/syslog,
+   falling back to journalctl -f or /var/log/messages if unavailable).
 - --list-connectors: print connectors and first 8 modes then exit.
 - --config FILE: load flags from a config file (supports quotes, comments with #).
 - --save-config FILE: write the current configuration as flags to a file.


### PR DESCRIPTION
## Summary
- Add fallback to `journalctl -f` or `/var/log/messages` when `/var/log/syslog` is unavailable for pane B
- Unconditionally toggle mpv `panscan` property on Ctrl+P for reliable panscan hotkey

## Testing
- `make` *(fails: fatal error: drm.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b8c67e3c808322b0bf59bd9903c6e7