### PR TITLE
Ensure blank syslog lines render

### DIFF
--- a/src/term_pane.c
+++ b/src/term_pane.c
@@ -568,10 +568,10 @@ term_pane* term_pane_create(const pane_layout *layout, int font_px, const char *
     int tex_w = tp->layout.cols * tp->font.cell_w;
     int tex_h = tp->layout.rows * tp->font.cell_h;
     pane_tex_init(&tp->surface, tex_w, tex_h);
-
-    // Prime screen empty
-    rebuild_surface(tp);
     tp->row_hash = calloc((size_t)tp->layout.rows, sizeof(uint32_t));
+
+    // Prime screen empty and populate row hashes so blank lines render
+    rebuild_surface(tp);
     return tp;
 }
 
@@ -601,8 +601,10 @@ term_pane* term_pane_create_cmd(const pane_layout *layout, int font_px, const ch
     int tex_w = tp->layout.cols * tp->font.cell_w;
     int tex_h = tp->layout.rows * tp->font.cell_h;
     pane_tex_init(&tp->surface, tex_w, tex_h);
-    rebuild_surface(tp);
     tp->row_hash = calloc((size_t)tp->layout.rows, sizeof(uint32_t));
+
+    // Prime screen empty and populate row hashes so blank lines render
+    rebuild_surface(tp);
     return tp;
 }
 


### PR DESCRIPTION
## Summary
- initialize terminal pane row hash array before first rebuild
- prime texture after allocation so empty lines get an opaque background

## Testing
- `make` *(fails: Package 'libdrm' not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b8cd8b7ee483229dc18005429b0dac