### PR TITLE
Increase syslog tail history

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Overview
 - Single-binary KMS compositor for the Linux console (no X/Wayland).
 - Uses DRM/KMS + GBM + EGL/GLES2 to present directly to the display.
 - Embeds libmpv (render API) to draw video; embeds libvterm for terminal panes.
-- Dynamically tiles three panes (“mosaic”): Pane C (Video), Pane A (btop), Pane B (syslog tail via `tail -F /var/log/syslog -n 100`).
+- Dynamically tiles three panes (“mosaic”): Pane C (Video), Pane A (btop), Pane B (syslog tail via `tail -F /var/log/syslog -n 500`).
 
 Why this approach
 - Only one DRM master can drive a KMS display at a time. This compositor provides
@@ -117,8 +117,8 @@ Flags
 - --video-frac PCT: percent of screen width for the video region (overrides --right-frac).
 - --pane-split PCT: percent of right column height for top pane (10..90, default 50).
 - --pane-a "CMD": shell command for top-right pane (default: btop).
-- --pane-b "CMD": shell command for bottom-right pane (default: tail -F /var/log/syslog -n 100,
-   falling back to journalctl -f or tail -F /var/log/messages -n 100 if unavailable).
+- --pane-b "CMD": shell command for bottom-right pane (default: tail -F /var/log/syslog -n 500,
+   falling back to journalctl -f or tail -F /var/log/messages -n 500 if unavailable).
 - --list-connectors: print connectors and first 8 modes then exit.
 - --config FILE: load flags from a config file (supports quotes, comments with #).
 - --save-config FILE: write the current configuration as flags to a file.

--- a/src/kms_mosaic.c
+++ b/src/kms_mosaic.c
@@ -1465,7 +1465,7 @@ int main(int argc, char **argv) {
                 "  --video-frac PCT        Override: video width percentage.\n"
                 "  --pane-split PCT        Top row height percentage for split layouts (default 50).\n"
                 "  --pane-a \"CMD\"           Command for Pane A (default: btop).\n"
-                "  --pane-b \"CMD\"           Command for Pane B (default: tail -F /var/log/syslog -n 100).\n"
+                "  --pane-b \"CMD\"           Command for Pane B (default: tail -F /var/log/syslog -n 500).\n"
                 "  --layout M              stack | row | 2x1 | 1x2 | 2over1 | 1over2 | overlay\n"
                 "  --roles RRR            Slot roles order, e.g. CAB (default CAB).\n"
                 "  --fs-cycle-sec SEC     Fullscreen cycle interval for 'c' key.\n\n"
@@ -1897,13 +1897,13 @@ int main(int argc, char **argv) {
             const char *cmd_b = NULL;
             if (access("/var/log/syslog", R_OK) == 0) {
                 cmd_b = "tail";
-                argv_b[0] = "tail"; argv_b[1] = "-F"; argv_b[2] = "/var/log/syslog"; argv_b[3] = "-n"; argv_b[4] = "100"; argv_b[5] = NULL;
+                argv_b[0] = "tail"; argv_b[1] = "-F"; argv_b[2] = "/var/log/syslog"; argv_b[3] = "-n"; argv_b[4] = "500"; argv_b[5] = NULL;
             } else if (access("/usr/bin/journalctl", X_OK) == 0) {
                 cmd_b = "journalctl";
                 argv_b[0] = "journalctl"; argv_b[1] = "-f"; argv_b[2] = NULL; argv_b[3] = NULL; argv_b[4] = NULL; argv_b[5] = NULL;
             } else {
                 cmd_b = "tail";
-                argv_b[0] = "tail"; argv_b[1] = "-F"; argv_b[2] = "/var/log/messages"; argv_b[3] = "-n"; argv_b[4] = "100"; argv_b[5] = NULL;
+                argv_b[0] = "tail"; argv_b[1] = "-F"; argv_b[2] = "/var/log/messages"; argv_b[3] = "-n"; argv_b[4] = "500"; argv_b[5] = NULL;
             }
             tp_b = term_pane_create(&lay_b, font_px_b, cmd_b, argv_b);
         }


### PR DESCRIPTION
## Summary
- expand default syslog pane tail to 500 lines
- update documentation to reflect wider log history

## Testing
- `make` *(fails: Package libdrm was not found in the pkg-config search path...)*

------
https://chatgpt.com/codex/tasks/task_e_68b8d4d0aff48322bf414b0299516311